### PR TITLE
Fix Supabase AI chat endpoint name

### DIFF
--- a/README_PATCH.md
+++ b/README_PATCH.md
@@ -14,7 +14,7 @@ Supabase Edge Function secrets:
 
 2) **Deploy edge function**
 ```
-supabase functions deploy legal-ai-chat
+supabase functions deploy ai-chat
 supabase functions secrets set OPENAI_API_KEY=sk-... ALLOWED_ORIGINS=https://docketchief.com,https://www.docketchief.com
 ```
 

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -120,9 +120,9 @@ export const AIService = {
 }
 
 export async function legalAiChat(req: ChatRequest): Promise<ChatResponse> {
-  const { data, error } = await supabase.functions.invoke('legal-ai-chat', { body: req })
+  const { data, error } = await supabase.functions.invoke('ai-chat', { body: req })
   if (error) {
-    console.error('[legal-ai-chat] error', error)
+    console.error('[ai-chat] error', error)
     throw new Error(error.message || 'AI function failed')
   }
   return data as ChatResponse


### PR DESCRIPTION
## Summary
- update the Supabase edge function invocation to call the correct `ai-chat` function
- align the deployment documentation with the corrected function name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690418cc8a04832991a956473b5261d6