### PR TITLE
Handle legacy payloads in legal AI chat function

### DIFF
--- a/supabase/functions/legal-ai-chat/index.ts
+++ b/supabase/functions/legal-ai-chat/index.ts
@@ -27,9 +27,43 @@ serve(async (req) => {
     }
 
     const body = await req.json().catch(() => ({}))
-    const messages = body?.messages ?? []
-    const system = body?.system ?? 'You are a precise legal drafting assistant. Write clearly, cite rules accurately, and never fabricate citations.'
-    const model = body?.model ?? 'gpt-4o-mini'
+
+    type RawMessage = { role?: string; content?: string }
+
+    const isValidRawMessage = (msg: RawMessage): msg is { role: string; content: string } =>
+      typeof msg?.role === 'string' && typeof msg?.content === 'string' && msg.content.trim().length > 0
+
+    let messages: { role: string; content: string }[] = []
+
+    if (Array.isArray(body?.messages)) {
+      messages = body.messages.filter(isValidRawMessage)
+    }
+
+    if (messages.length === 0) {
+      const fallbackMessage =
+        typeof body?.message === 'string'
+          ? body.message
+          : typeof body?.prompt === 'string'
+            ? body.prompt
+            : null
+
+      if (fallbackMessage && fallbackMessage.trim().length > 0) {
+        messages = [{ role: 'user', content: fallbackMessage }]
+      }
+    }
+
+    if (messages.length === 0) {
+      return new Response(JSON.stringify({ error: 'Message is required' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json', ...corsHeaders(origin) },
+      })
+    }
+
+    const system =
+      typeof body?.system === 'string' && body.system.trim().length > 0
+        ? body.system
+        : 'You are a precise legal drafting assistant. Write clearly, cite rules accurately, and never fabricate citations.'
+    const model = typeof body?.model === 'string' && body.model.trim().length > 0 ? body.model : 'gpt-4o-mini'
 
     const payload = {
       model,


### PR DESCRIPTION
## Summary
- normalize incoming payloads for the legal AI chat function by validating structured messages
- add support for legacy `message` and `prompt` fields so single-string requests are accepted
- keep sensible defaults for system and model values when not provided

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69041b064d50832985b8070d8cbe6417