### PR TITLE
Fix legal AI edge function invocation

### DIFF
--- a/README_PATCH.md
+++ b/README_PATCH.md
@@ -14,7 +14,7 @@ Supabase Edge Function secrets:
 
 2) **Deploy edge function**
 ```
-supabase functions deploy ai-chat
+supabase functions deploy legal-ai-chat
 supabase functions secrets set OPENAI_API_KEY=sk-... ALLOWED_ORIGINS=https://docketchief.com,https://www.docketchief.com
 ```
 

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -120,9 +120,9 @@ export const AIService = {
 }
 
 export async function legalAiChat(req: ChatRequest): Promise<ChatResponse> {
-  const { data, error } = await supabase.functions.invoke('ai-chat', { body: req })
+  const { data, error } = await supabase.functions.invoke('legal-ai-chat', { body: req })
   if (error) {
-    console.error('[ai-chat] error', error)
+    console.error('[legal-ai-chat] error', error)
     throw new Error(error.message || 'AI function failed')
   }
   return data as ChatResponse

--- a/test-plan.html
+++ b/test-plan.html
@@ -111,7 +111,7 @@
             <h3>✅ AI Chat Integration</h3>
             <p><strong>Test:</strong> Legal AI assistant interface</p>
             <p><strong>Result:</strong> PASS - Chat interface loads and accepts input</p>
-            <p><strong>Note:</strong> Requires 'ai-chat' edge function for actual responses</p>
+            <p><strong>Note:</strong> Requires 'legal-ai-chat' edge function for actual responses</p>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- point the frontend AI client at the deployed `legal-ai-chat` edge function and update logging
- refresh deployment docs and the QA plan to reference the correct edge function name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904e925353483299117fcb45fb96595