### PR TITLE
perf: lazy load feature modules in AppLayout

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,49 +1,48 @@
-import React, { useState } from 'react';
-import { MotionCard } from './MotionCard';
-import { DocumentEditor } from './DocumentEditor';
-import { CaseAnalyzer } from './CaseAnalyzer';
-import RulesDatabase from './RulesDatabase';
-import RebuttalAssistant from './RebuttalAssistant';
-import CaseLawDatabase from './CaseLawDatabase';
-import { BriefGenerator } from './BriefGenerator';
-import { ClientPortal } from './ClientPortal';
-import { DocumentUpload } from './DocumentUpload';
-import { DocumentManager } from './DocumentManager';
-import { UserDashboard } from './UserDashboard';
-import { AuthModal } from './AuthModal';
-import { AIChat } from './AIChat';
-import { ConversationImport } from './ConversationImport';
-import { ConversationManager } from './ConversationManager';
-import { AdvancedSearch } from './AdvancedSearch';
-import { CollaborationTools } from './CollaborationTools';
-import { CaseManagementDashboard } from './CaseManagementDashboard';
-import { LegalResearchTool } from './LegalResearchTool';
-import { CalendarDashboard } from './CalendarDashboard';
-import { EmailDashboard } from './EmailDashboard';
-import { LegalToolsGrid } from './LegalToolsGrid';
-import { AnalyticsDashboard } from './AnalyticsDashboard';
-import { ContractDraftingTool } from './ContractDraftingTool';
-import LegalDatabaseSearch from './LegalDatabaseSearch';
-import CourtListenerAPI from './CourtListenerAPI';
-import PaymentPlans from './PaymentPlans';
-import { PaymentPortal } from './PaymentPortal';
-import PaymentSuccess from './PaymentSuccess';
-import PaymentCancel from './PaymentCancel';
-import { SubscriptionDashboard } from './SubscriptionDashboard';
-import { ServiceStatus } from './ServiceStatus';
-import DocumentAnalyzer from './DocumentAnalyzer';
-import { AlertDashboard } from './AlertDashboard';
-import { AdminSubscriptionAnalytics } from './AdminSubscriptionAnalytics';
-
-
-import { TemplateLibrary } from './TemplateLibrary';
-import { TemplateEditor } from './TemplateEditor';
-import { SystemMonitor } from './SystemMonitor';
+import React, { Suspense, lazy, useState } from 'react';
 import { ErrorBoundary } from './ErrorBoundary';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from './ui/button';
 import { User, LogOut, CreditCard, Settings, Bell } from 'lucide-react';
-import { TemplateRecord, useTemplateLibrary } from '@/contexts/TemplateContext';
+import type { TemplateRecord } from '@/contexts/TemplateContext';
+import { useTemplateLibrary } from '@/contexts/TemplateContext';
+
+const DocumentEditor = lazy(() => import('./DocumentEditor').then(module => ({ default: module.DocumentEditor })));
+const CaseAnalyzer = lazy(() => import('./CaseAnalyzer').then(module => ({ default: module.CaseAnalyzer })));
+const RulesDatabase = lazy(() => import('./RulesDatabase'));
+const RebuttalAssistant = lazy(() => import('./RebuttalAssistant'));
+const CaseLawDatabase = lazy(() => import('./CaseLawDatabase'));
+const BriefGenerator = lazy(() => import('./BriefGenerator').then(module => ({ default: module.BriefGenerator })));
+const ClientPortal = lazy(() => import('./ClientPortal').then(module => ({ default: module.ClientPortal })));
+const DocumentUpload = lazy(() => import('./DocumentUpload'));
+const DocumentManager = lazy(() => import('./DocumentManager').then(module => ({ default: module.DocumentManager })));
+const UserDashboard = lazy(() => import('./UserDashboard').then(module => ({ default: module.UserDashboard })));
+const AuthModal = lazy(() => import('./AuthModal').then(module => ({ default: module.AuthModal })));
+const AIChat = lazy(() => import('./AIChat').then(module => ({ default: module.AIChat })));
+const ConversationImport = lazy(() => import('./ConversationImport').then(module => ({ default: module.ConversationImport })));
+const ConversationManager = lazy(() => import('./ConversationManager').then(module => ({ default: module.ConversationManager })));
+const AdvancedSearch = lazy(() => import('./AdvancedSearch').then(module => ({ default: module.AdvancedSearch })));
+const CollaborationTools = lazy(() => import('./CollaborationTools').then(module => ({ default: module.CollaborationTools })));
+const CaseManagementDashboard = lazy(() => import('./CaseManagementDashboard').then(module => ({ default: module.CaseManagementDashboard })));
+const LegalResearchTool = lazy(() => import('./LegalResearchTool').then(module => ({ default: module.LegalResearchTool })));
+const CalendarDashboard = lazy(() => import('./CalendarDashboard').then(module => ({ default: module.CalendarDashboard })));
+const EmailDashboard = lazy(() => import('./EmailDashboard').then(module => ({ default: module.EmailDashboard })));
+const LegalToolsGrid = lazy(() => import('./LegalToolsGrid').then(module => ({ default: module.LegalToolsGrid })));
+const AnalyticsDashboard = lazy(() => import('./AnalyticsDashboard').then(module => ({ default: module.AnalyticsDashboard })));
+const ContractDraftingTool = lazy(() => import('./ContractDraftingTool').then(module => ({ default: module.ContractDraftingTool })));
+const LegalDatabaseSearch = lazy(() => import('./LegalDatabaseSearch'));
+const CourtListenerAPI = lazy(() => import('./CourtListenerAPI'));
+const PaymentPlans = lazy(() => import('./PaymentPlans'));
+const PaymentPortal = lazy(() => import('./PaymentPortal').then(module => ({ default: module.PaymentPortal })));
+const PaymentSuccess = lazy(() => import('./PaymentSuccess'));
+const PaymentCancel = lazy(() => import('./PaymentCancel'));
+const SubscriptionDashboard = lazy(() => import('./SubscriptionDashboard').then(module => ({ default: module.SubscriptionDashboard })));
+const ServiceStatus = lazy(() => import('./ServiceStatus').then(module => ({ default: module.ServiceStatus })));
+const DocumentAnalyzer = lazy(() => import('./DocumentAnalyzer'));
+const AlertDashboard = lazy(() => import('./AlertDashboard').then(module => ({ default: module.AlertDashboard })));
+const AdminSubscriptionAnalytics = lazy(() => import('./AdminSubscriptionAnalytics').then(module => ({ default: module.AdminSubscriptionAnalytics })));
+const TemplateLibrary = lazy(() => import('./TemplateLibrary').then(module => ({ default: module.TemplateLibrary })));
+const TemplateEditor = lazy(() => import('./TemplateEditor').then(module => ({ default: module.TemplateEditor })));
+const SystemMonitor = lazy(() => import('./SystemMonitor'));
 
 export const AppLayout = () => {
   const { user, signOut } = useAuth();
@@ -374,21 +373,29 @@ export const AppLayout = () => {
           </div>
         </nav>
         
-        <main>{renderContent()}</main>
-        
+        <main>
+          <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading...</div>}>
+            {renderContent()}
+          </Suspense>
+        </main>
+
         {selectedMotion && (
-          <DocumentEditor
-            motionType={selectedMotion}
-            onClose={() => setSelectedMotion(null)}
-          />
+          <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading document editor...</div>}>
+            <DocumentEditor
+              motionType={selectedMotion}
+              onClose={() => setSelectedMotion(null)}
+            />
+          </Suspense>
         )}
-        
-        <AuthModal
-          isOpen={showAuthModal}
-          onClose={() => setShowAuthModal(false)}
-          mode={authMode}
-          onModeChange={setAuthMode}
-        />
+
+        <Suspense fallback={null}>
+          <AuthModal
+            isOpen={showAuthModal}
+            onClose={() => setShowAuthModal(false)}
+            mode={authMode}
+            onModeChange={setAuthMode}
+          />
+        </Suspense>
       </div>
     </ErrorBoundary>
   );

--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -166,7 +166,6 @@ export const DocumentUpload: React.FC = () => {
                   <FileText className="h-4 w-4" />
                   PDF Files
                 </div>
-                </div>
                 <div className="flex items-center gap-2 text-sm text-gray-500">
                   <FileText className="h-4 w-4" />
                   DOCX Files


### PR DESCRIPTION
## Summary
- lazy-load the large feature modules in `AppLayout` so they are fetched on demand instead of in the initial bundle
- wrap lazy modules with `Suspense` fallbacks and keep the authentication modal available without blocking the UI
- fix a mismatched closing tag in `DocumentUpload` that caused the production build to fail

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6904ed8f5f888329a97faac78b8e93a7